### PR TITLE
Fix hub_mixin.py pop error

### DIFF
--- a/segmentation_models_pytorch/base/hub_mixin.py
+++ b/segmentation_models_pytorch/base/hub_mixin.py
@@ -120,7 +120,7 @@ class SMPHubMixin(PyTorchModelHubMixin):
         finally:
             # delete the additional attributes
             self._del_attrs(["save_directory", "metrics", "dataset"])
-            self._hub_mixin_config.pop("_model_class")
+            self._hub_mixin_config.pop("_model_class", None)
 
         return result
 


### PR DESCRIPTION
Fix the error caused by pop operation on non-existing key in dict.