### PR TITLE
Modify Jaccard, Dice and Tversky losses

### DIFF
--- a/segmentation_models_pytorch/losses/_functional.py
+++ b/segmentation_models_pytorch/losses/_functional.py
@@ -4,6 +4,7 @@ import numpy as np
 from typing import Optional
 
 import torch
+import torch.linalg as LA
 import torch.nn.functional as F
 
 __all__ = [
@@ -190,20 +191,14 @@ def soft_tversky_score(
 
     """
     assert output.size() == target.size()
-    if dims is not None:
-        difference = torch.norm(output - target, p=1, dim=dims)
-        output_sum = torch.sum(output, dim=dims)
-        target_sum = torch.sum(target, dim=dims)
-        intersection = (output_sum + target_sum - difference) / 2  # TP
-        fp = output_sum - intersection
-        fn = target_sum - intersection
-    else:
-        difference = torch.norm(output - target, p=1)
-        output_sum = torch.sum(output)
-        target_sum = torch.sum(target)
-        intersection = (output_sum + target_sum - difference) / 2  # TP
-        fp = output_sum - intersection
-        fn = target_sum - intersection
+
+    output_sum = torch.sum(output, dim=dims)
+    target_sum = torch.sum(target, dim=dims)
+    difference = LA.vector_norm(output - target, ord=1, dim=dims)
+
+    intersection = (output_sum + target_sum - difference) / 2  # TP
+    fp = output_sum - intersection
+    fn = target_sum - intersection
 
     tversky_score = (intersection + smooth) / (
         intersection + alpha * fp + beta * fn + smooth


### PR DESCRIPTION
The Jaccard, Dice and Tversky losses in `losses._functional` are modified based on [JDTLoss](https://github.com/zifuwanggg/JDTLosses/blob/master/losses/jdt_loss.py).

* Since Jaccard and Dice losses are special cases of the Tversky loss [1], the implementation is simplified by calling `soft_tversky_score` when calculating both `jaccard_score` and `dice_score`.

* The original loss functions are incompatible with soft labels. For example, with a ground truth value of 0.5 for a single pixel, the Dice loss is minimized when the predicted value is 1, which is clearly erroneous. To address this, the intersection term is rewritten as $\frac{\|x\|_1 + \|y\|_1 - \|x-y\|_1}{2}$. This reformulation has been proven to retain equivalence with the original versions when the ground truth is binary (i.e. one-hot hard labels), while resolving the issue with soft labels [1, 2].

### Example
```
import torch
import torch.linalg as LA
import torch.nn.functional as F

torch.manual_seed(0)

b, c, h, w = 4, 3, 32, 32
dims = (0, 2, 3)

pred = torch.rand(b, c, h, w).softmax(dim=1)
soft_label = torch.rand(b, c, h, w).softmax(dim=1)
hard_label = torch.randint(low=0, high=c, size=(b, h, w))
one_hot_label = F.one_hot(hard_label, c).permute(0, 3, 1, 2)

def dice_old(x, y, dims):
    cardinality = torch.sum(x, dim=dims) + torch.sum(y, dim=dims)
    intersection = torch.sum(x * y, dim=dims)
    return 2 * intersection / cardinality

def dice_new(x, y, dims):
    cardinality = torch.sum(x, dim=dims) + torch.sum(y, dim=dims)
    difference = LA.vector_norm(x - y, ord=1, dim=dims)
    intersection = (cardinality - difference) / 2
    return 2 * intersection / cardinality

print(dice_old(pred, one_hot_label, dims), dice_new(pred, one_hot_label, dims))
print(dice_old(pred, soft_label, dims), dice_new(pred, soft_label, dims))
print(dice_old(pred, pred, dims), dice_new(pred, pred, dims))

# tensor([0.3345, 0.3310, 0.3317]) tensor([0.3345, 0.3310, 0.3317])
# tensor([0.3321, 0.3333, 0.3350]) tensor([0.8680, 0.8690, 0.8700])
# tensor([0.3487, 0.3502, 0.3544]) tensor([1., 1., 1.])
```

### References
[1] Dice Semimetric Losses: Optimizing the Dice Score with Soft Labels. Zifu Wang, Teodora Popordanoska, Jeroen Bertels, Robin Lemmens, Matthew B. Blaschko. *MICCAI 2023*.

[2] Jaccard Metric Losses: Optimizing the Jaccard Index with Soft Labels. Zifu Wang, Xuefei Ning, Matthew B. Blaschko. *NeurIPS 2023*.