### PR TITLE
Dependencies: torch 1.9+ required

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     'six>=1.5',
     'timm>=0.9',
     'torch>=1.10',
-    'torchvision>=0.11',
+    'torchvision>=0.11.1',
     'tqdm>=4.42.1',
 ]
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
     'pretrainedmodels>=0.7.1',
     'six>=1.5',
     'timm>=0.9',
-    'torch>=1.9',
-    'torchvision>=0.10',
+    'torch>=1.10',
+    'torchvision>=0.11',
     'tqdm>=4.42.1',
 ]
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ dependencies = [
     'pretrainedmodels>=0.7.1',
     'six>=1.5',
     'timm>=0.9',
-    'torch>=1.8',
-    'torchvision>=0.9',
+    'torch>=1.9',
+    'torchvision>=0.10',
     'tqdm>=4.42.1',
 ]
 dynamic = ['version']

--- a/requirements/minimum.old
+++ b/requirements/minimum.old
@@ -5,6 +5,6 @@ pillow==8.0.0
 pretrainedmodels==0.7.1
 six==1.5.0
 timm==0.9.0
-torch==1.10.0
+torch==1.10.0+cu102
 torchvision==0.11.0
 tqdm==4.42.1

--- a/requirements/minimum.old
+++ b/requirements/minimum.old
@@ -5,6 +5,6 @@ pillow==8.0.0
 pretrainedmodels==0.7.1
 six==1.5.0
 timm==0.9.0
-torch==1.10.0+cu102
-torchvision==0.11.0
+torch==1.10.0
+torchvision==0.11.1
 tqdm==4.42.1

--- a/requirements/minimum.old
+++ b/requirements/minimum.old
@@ -5,6 +5,6 @@ pillow==8.0.0
 pretrainedmodels==0.7.1
 six==1.5.0
 timm==0.9.0
-torch==1.8.0
-torchvision==0.9.0
+torch==1.9.0
+torchvision==0.10.0
 tqdm==4.42.1

--- a/requirements/minimum.old
+++ b/requirements/minimum.old
@@ -5,6 +5,6 @@ pillow==8.0.0
 pretrainedmodels==0.7.1
 six==1.5.0
 timm==0.9.0
-torch==1.9.0
-torchvision==0.10.0
+torch==1.10.0
+torchvision==0.11.0
 tqdm==4.42.1


### PR DESCRIPTION
#927 uses `torch.linalg.vector_norm`, which requires torch 1.9+. This wasn't caught in CI because the tests weren't run after #918 was merged.

P.S. We should require all tests to pass before a PR can be merged. Let me know if you need help updating the branch protection rules.