### PR TITLE
fix(examples): correct Colab links

### DIFF
--- a/examples/camvid_segmentation_multiclass.ipynb
+++ b/examples/camvid_segmentation_multiclass.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qubvel/segmentation_models.pytorch/blob/main/examples/cars%20segmentation%20(camvid).ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qubvel/segmentation_models.pytorch/blob/main/examples/camvid_segmentation_multiclass.ipynb)"
    ]
   },
   {

--- a/examples/cars segmentation (camvid).ipynb
+++ b/examples/cars segmentation (camvid).ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qubvel/segmentation_models.pytorch/blob/main/examples/cars%20segmentation%20(camvid).ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/qubvel/segmentation_models.pytorch/blob/main/examples/cars%20segmentation%20%28camvid%29.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
The colab links were broken for 2 example notebooks :
- `examples/cars segmentation (camvid).ipynb` : The closing parenthesis indicated the end of the link, so I URL encoded them
- `examples/camvid_segmentation_multiclass.ipynb` : It had the link of the previous notebook