### PR TITLE
Fix DeepLabV3Plus encoder depth

### DIFF
--- a/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
@@ -70,7 +70,7 @@ class DeepLabV3Decoder(nn.Sequential):
 class DeepLabV3PlusDecoder(nn.Module):
     def __init__(
         self,
-        encoder_channels: Sequence[int, ...],
+        encoder_channels: Sequence[int],
         encoder_depth: Literal[3, 4, 5],
         out_channels: int,
         atrous_rates: Iterable[int],
@@ -79,7 +79,11 @@ class DeepLabV3PlusDecoder(nn.Module):
         aspp_dropout: float,
     ):
         super().__init__()
-        if output_stride not in {8, 16}:
+        if encoder_depth not in (3, 4, 5):
+            raise ValueError(
+                "Encoder depth should be 3, 4 or 5, got {}.".format(encoder_depth)
+            )
+        if output_stride not in (8, 16):
             raise ValueError(
                 "Output stride should be 8 or 16, got {}.".format(output_stride)
             )

--- a/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
@@ -71,6 +71,7 @@ class DeepLabV3PlusDecoder(nn.Module):
     def __init__(
         self,
         encoder_channels: Sequence[int, ...],
+        encoder_depth: Literal[3, 4, 5],
         out_channels: int,
         atrous_rates: Iterable[int],
         output_stride: Literal[8, 16],
@@ -104,7 +105,14 @@ class DeepLabV3PlusDecoder(nn.Module):
         scale_factor = 2 if output_stride == 8 else 4
         self.up = nn.UpsamplingBilinear2d(scale_factor=scale_factor)
 
-        highres_in_channels = encoder_channels[-4]
+        if encoder_depth == 3 and output_stride == 8:
+            self.highres_input_index = -2
+        elif encoder_depth == 3 or encoder_depth == 4:
+            self.highres_input_index = -3
+        else:
+            self.highres_input_index = -4
+
+        highres_in_channels = encoder_channels[self.highres_input_index]
         highres_out_channels = 48  # proposed by authors of paper
         self.block1 = nn.Sequential(
             nn.Conv2d(
@@ -128,7 +136,7 @@ class DeepLabV3PlusDecoder(nn.Module):
     def forward(self, *features):
         aspp_features = self.aspp(features[-1])
         aspp_features = self.up(aspp_features)
-        high_res_features = self.block1(features[-4])
+        high_res_features = self.block1(features[self.highres_input_index])
         concat_features = torch.cat([aspp_features, high_res_features], dim=1)
         fused_features = self.block2(concat_features)
         return fused_features

--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -129,7 +129,8 @@ class DeepLabV3Plus(SegmentationModel):
             Available options are **"sigmoid"**, **"softmax"**, **"logsoftmax"**, **"tanh"**, **"identity"**,
                 **callable** and **None**.
             Default is **None**
-        upsampling: Final upsampling factor. Default is 4 to preserve input-output spatial shape identity
+        upsampling: Final upsampling factor. Default is 4 to preserve input-output spatial shape identity. In case
+            **encoder_depth** and **encoder_output_stride** are 3 and 16 resp., set **upsampling** to 2 to preserve.
         aux_params: Dictionary with parameters of the auxiliary output (classification head). Auxiliary output is build
             on top of encoder if **aux_params** is not **None** (default). Supported params:
                 - classes (int): A number of classes

--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -150,7 +150,7 @@ class DeepLabV3Plus(SegmentationModel):
     def __init__(
         self,
         encoder_name: str = "resnet34",
-        encoder_depth: int = 5,
+        encoder_depth: Literal[3, 4, 5] = 5,
         encoder_weights: Optional[str] = "imagenet",
         encoder_output_stride: Literal[8, 16] = 16,
         decoder_channels: int = 256,
@@ -177,6 +177,7 @@ class DeepLabV3Plus(SegmentationModel):
 
         self.decoder = DeepLabV3PlusDecoder(
             encoder_channels=self.encoder.out_channels,
+            encoder_depth=encoder_depth,
             out_channels=decoder_channels,
             atrous_rates=decoder_atrous_rates,
             output_stride=encoder_output_stride,


### PR DESCRIPTION
Hi, @qubvel. Thanks for your great work!

This PR fixes #377 and is used to be PR #561, which staled and closed before.

I ran into the issue #377 again to find that the PR can still be effective.
(My typical use case involves processing small images in real time, and a small encoder depth is preferred.)
So, I made some maintenance and rebased on edadc0d.

## Update

1. Fix the feature index mismatch which occurs when `encoder_depth` is 3 and 4.
   * Please refer to the attached file to see the combination of tensor shapes in each cases: [tensor_shapes.md](https://github.com/qubvel/segmentation_models.pytorch/files/8053614/tensor_shapes.md).
2. Modify the docstring for `upsampling` argument to state the condition to preserve input-output shape.
   * In case (`encoder_depth`, `encoder_output_stride`) = (3, 16), `upsampling` should be set to 2.
3. Modify a type hint and add a value check.
   * Type hint error: `Squence[int, ...]` should be `Squence[int]`.
   * Value check: add a validation to make sure `encoder_depth` is either 3, 4, or 5.

## Test Code

```python
from itertools import product

import torch
import segmentation_models_pytorch as smp

input_shape = (10, 3, 192, 128)
input_tensor = torch.zeros(input_shape)
for up, depth, stride in product((2, 4), (3, 4, 5), (8, 16)):
    net = smp.DeepLabV3Plus(
        encoder_name="timm-mobilenetv3_small_minimal_100",
        encoder_weights="imagenet",
        encoder_depth=depth,
        encoder_output_stride=stride,
        upsampling=up,
        classes=1,
        activation=None
    )
    print(f"encoder_depth={depth}, encoder_output_stride={stride:2}, upsampling={up}")
    output_shape = tuple(net(input_tensor).shape)
    preserved = all(input_shape[i] == output_shape[i] for i in (0, 2, 3))
    print(f"  output shape: {output_shape}, preserve shape: {preserved}")
```

output
```text
encoder_depth=3, encoder_output_stride= 8, upsampling=2
  output shape: (10, 1, 96, 64), preserve shape: False
encoder_depth=3, encoder_output_stride=16, upsampling=2
  output shape: (10, 1, 192, 128), preserve shape: True
encoder_depth=4, encoder_output_stride= 8, upsampling=2
  output shape: (10, 1, 96, 64), preserve shape: False
encoder_depth=4, encoder_output_stride=16, upsampling=2
  output shape: (10, 1, 96, 64), preserve shape: False
encoder_depth=5, encoder_output_stride= 8, upsampling=2
  output shape: (10, 1, 96, 64), preserve shape: False
encoder_depth=5, encoder_output_stride=16, upsampling=2
  output shape: (10, 1, 96, 64), preserve shape: False
encoder_depth=3, encoder_output_stride= 8, upsampling=4
  output shape: (10, 1, 192, 128), preserve shape: True
encoder_depth=3, encoder_output_stride=16, upsampling=4
  output shape: (10, 1, 384, 256), preserve shape: False
encoder_depth=4, encoder_output_stride= 8, upsampling=4
  output shape: (10, 1, 192, 128), preserve shape: True
encoder_depth=4, encoder_output_stride=16, upsampling=4
  output shape: (10, 1, 192, 128), preserve shape: True
encoder_depth=5, encoder_output_stride= 8, upsampling=4
  output shape: (10, 1, 192, 128), preserve shape: True
encoder_depth=5, encoder_output_stride=16, upsampling=4
  output shape: (10, 1, 192, 128), preserve shape: True
```