### PR TITLE
[Draft] Fix encoder depth & output stride on DeeplabV3 & DeeplabV3+

### DIFF
--- a/segmentation_models_pytorch/__init__.py
+++ b/segmentation_models_pytorch/__init__.py
@@ -26,7 +26,9 @@ import torch as _torch
 
 # Suppress the specific SyntaxWarning for `pretrainedmodels`
 warnings.filterwarnings("ignore", message="is with a literal", category=SyntaxWarning)
-warnings.filterwarnings("ignore", message=r'"is" with \'str\' literal.*', category=SyntaxWarning) # for python >= 3.12
+warnings.filterwarnings(
+    "ignore", message=r'"is" with \'str\' literal.*', category=SyntaxWarning
+)  # for python >= 3.12
 
 
 def create_model(

--- a/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/decoder.py
@@ -61,7 +61,6 @@ class DeepLabV3Decoder(nn.Sequential):
             nn.BatchNorm2d(out_channels),
             nn.ReLU(),
         )
-        self.out_channels = out_channels
 
     def forward(self, *features):
         return super().forward(features[-1])
@@ -71,6 +70,7 @@ class DeepLabV3PlusDecoder(nn.Module):
     def __init__(
         self,
         encoder_channels: Sequence[int, ...],
+        encoder_depth: int,
         out_channels: int,
         atrous_rates: Iterable[int],
         output_stride: Literal[8, 16],
@@ -78,13 +78,12 @@ class DeepLabV3PlusDecoder(nn.Module):
         aspp_dropout: float,
     ):
         super().__init__()
-        if output_stride not in {8, 16}:
+        if encoder_depth < 3:
             raise ValueError(
-                "Output stride should be 8 or 16, got {}.".format(output_stride)
+                "Encoder depth for DeepLabV3Plus decoder cannot be less than 3, got {}.".format(
+                    encoder_depth
+                )
             )
-
-        self.out_channels = out_channels
-        self.output_stride = output_stride
 
         self.aspp = nn.Sequential(
             ASPP(
@@ -101,10 +100,10 @@ class DeepLabV3PlusDecoder(nn.Module):
             nn.ReLU(),
         )
 
-        scale_factor = 2 if output_stride == 8 else 4
+        scale_factor = 4 if output_stride == 16 and encoder_depth > 3 else 2
         self.up = nn.UpsamplingBilinear2d(scale_factor=scale_factor)
 
-        highres_in_channels = encoder_channels[-4]
+        highres_in_channels = encoder_channels[2]
         highres_out_channels = 48  # proposed by authors of paper
         self.block1 = nn.Sequential(
             nn.Conv2d(
@@ -128,7 +127,7 @@ class DeepLabV3PlusDecoder(nn.Module):
     def forward(self, *features):
         aspp_features = self.aspp(features[-1])
         aspp_features = self.up(aspp_features)
-        high_res_features = self.block1(features[-4])
+        high_res_features = self.block1(features[2])
         concat_features = torch.cat([aspp_features, high_res_features], dim=1)
         fused_features = self.block2(concat_features)
         return fused_features
@@ -228,13 +227,13 @@ class ASPP(nn.Module):
 class SeparableConv2d(nn.Sequential):
     def __init__(
         self,
-        in_channels,
-        out_channels,
-        kernel_size,
-        stride=1,
-        padding=0,
-        dilation=1,
-        bias=True,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int = 1,
+        padding: int = 0,
+        dilation: int = 1,
+        bias: bool = True,
     ):
         dephtwise_conv = nn.Conv2d(
             in_channels,

--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -43,7 +43,7 @@ class DeepLabV3(SegmentationModel):
                 - dropout (float): Dropout factor in [0, 1)
                 - activation (str): An activation function to apply "sigmoid"/"softmax"
                     (could be **None** to return logits)
-        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models. 
+        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models.
             Keys with ``None`` values are pruned before passing.
 
     Returns:
@@ -79,7 +79,7 @@ class DeepLabV3(SegmentationModel):
                     encoder_output_stride
                 )
             )
-        
+
         self.encoder = get_encoder(
             encoder_name,
             in_channels=in_channels,
@@ -91,7 +91,7 @@ class DeepLabV3(SegmentationModel):
 
         if upsampling is None:
             if encoder_depth <= 3:
-                scale_factor = 2 ** encoder_depth
+                scale_factor = 2**encoder_depth
             else:
                 scale_factor = encoder_output_stride
         else:
@@ -153,7 +153,7 @@ class DeepLabV3Plus(SegmentationModel):
                 - dropout (float): Dropout factor in [0, 1)
                 - activation (str): An activation function to apply "sigmoid"/"softmax"
                     (could be **None** to return logits)
-        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models. 
+        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models.
             Keys with ``None`` values are pruned before passing.
 
     Returns:

--- a/segmentation_models_pytorch/decoders/deeplabv3/model.py
+++ b/segmentation_models_pytorch/decoders/deeplabv3/model.py
@@ -43,7 +43,7 @@ class DeepLabV3(SegmentationModel):
                 - dropout (float): Dropout factor in [0, 1)
                 - activation (str): An activation function to apply "sigmoid"/"softmax"
                     (could be **None** to return logits)
-        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models.
+        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models. 
             Keys with ``None`` values are pruned before passing.
 
     Returns:
@@ -79,7 +79,7 @@ class DeepLabV3(SegmentationModel):
                     encoder_output_stride
                 )
             )
-
+        
         self.encoder = get_encoder(
             encoder_name,
             in_channels=in_channels,
@@ -91,7 +91,7 @@ class DeepLabV3(SegmentationModel):
 
         if upsampling is None:
             if encoder_depth <= 3:
-                scale_factor = 2**encoder_depth
+                scale_factor = 2 ** encoder_depth
             else:
                 scale_factor = encoder_output_stride
         else:
@@ -153,7 +153,7 @@ class DeepLabV3Plus(SegmentationModel):
                 - dropout (float): Dropout factor in [0, 1)
                 - activation (str): An activation function to apply "sigmoid"/"softmax"
                     (could be **None** to return logits)
-        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models.
+        kwargs: Arguments passed to the encoder class ``__init__()`` function. Applies only to ``timm`` models. 
             Keys with ``None`` values are pruned before passing.
 
     Returns:


### PR DESCRIPTION
Hi @qubvel ,

This PR solve issues in DeepLabV3 and DeepLabV3+ models that may occur with different `encoder_depth` and `output_stride` configurations.

## Updates & Fixes
1. Added validation for the `output_stride` parameter.
2. Removed redundant `out_channels` parameter in the decoder.
3. Fixed `segmentation_head.upsampling` to ensure input and output sizes match in DeepLabV3 for all `encoder_depth` and `output_stride` settings.
4. Adjusted `high_res_features` in DeepLabV3+ to always use a 1/4 resolution of the input, ensuring no errors occur with `encoder_depth` values between 3 and 5.


## Encoder Depth & Output Stride
- Test model: ResNet18
- Test input shape: (256, 256)
### Encoder Output Shape
| Output Stride \ Depth |     1      |    2     |    3     |    4     |    5     |
|:---------------------:|:----------:|:--------:|:--------:|:--------:|:--------:|
|          32           | (128, 128) | (64, 64) | (32, 32) | (16, 16) |  (8, 8)  |
|          16           | (128, 128) | (64, 64) | (32, 32) | (16, 16) | (16, 16) |
|           8           | (128, 128) | (64, 64) | (32, 32) | (32, 32) | (32, 32) |
### Downsample factor
| Output Stride \ Depth |  1  |  2  |  3  |  4   |  5   |
|:---------------------:|:---:|:---:|:---:|:----:|:----:|
|          32           | 1/2 | 1/4 | 1/8 | 1/16 | 1/32 |
|          16           | 1/2 | 1/4 | 1/8 | 1/16 | 1/16 |
|           8           | 1/2 | 1/4 | 1/8 | 1/8  | 1/8  |
## DeeplabV3
From the tables above:

When `encoder_depth` is between 1 and 3, the upsampling ratio between input and output is `scale_factor=2**encoder_depth`.
When `encoder_depth` is 4 or 5, the upsampling ratio is `scale_factor=output_stride`.

The following code ensures input and output sizes match for all `encoder_depth` values in DeepLabV3:
```python
if upsampling is None:
    if encoder_depth <= 3:
        scale_factor = 2**encoder_depth
    else:
        scale_factor = encoder_output_stride
else:
    scale_factor = upsampling
```
### Test Code
```python
import torch
import segmentation_models_pytorch as smp

def test_depth(depth, output_stride):
    x = torch.rand(1, 3, 256, 256)
    model = smp.DeepLabV3(
        "resnet18",
        encoder_depth=depth,
        encoder_weights=None,
        encoder_output_stride=output_stride,
    ).eval()
    y = model(x)
    assert x.shape[2:] == y.shape[2:]
    print(
        f"Encoder Depth: {depth} | Output Stride: {output_stride} : "
        f"Input/Output Shape {x.detach().numpy().shape[2:]}/{y.detach().numpy().shape[2:]}"      
    )
if __name__ == "__main__":
    for depth in [5, 4, 3, 2, 1]:
        for output_stride in [8, 16]:
            test_depth(depth, output_stride)
    print("all pass")
```
### Output
```python
Encoder Depth: 5 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 5 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 4 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 4 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 3 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 3 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 2 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 2 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 1 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 1 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
all pass
```

## DeeplabV3+

Originally, DeepLabV3+ only supported `encoder_depth` values of 4 and 5 due to:
```python
high_res_features = self.block1(features[-4])
```
- With `encoder_depth=5`, there are no errors.
- With `encoder_depth=4`, errors occur with MixVisionTransformer encoders (e.g., dump feature channel = 0).
- With `encoder_depth=3`, it triggers a "list index out of range" error.

By fixing `high_res_features` to always use the 1/4 resolution input and limiting `encoder_depth` to >=3, these issues are resolved:
```python
high_res_features = self.block1(features[2])
```

### Test Code
```python
import torch
import segmentation_models_pytorch as smp

def test_depth(depth, output_stride):
    x = torch.rand(1, 3, 256, 256)
    model = smp.DeepLabV3Plus(
        "mit_b0",
        encoder_depth=depth,
        encoder_weights=None,
        encoder_output_stride=output_stride,
    ).eval()
    y = model(x)
    assert x.shape[2:] == y.shape[2:]
    print(
        f"Encoder Depth: {depth} | Output Stride: {output_stride} : "
        f"Input/Output Shape {x.detach().numpy().shape[2:]}/{y.detach().numpy().shape[2:]}"      
    )
if __name__ == "__main__":
    for depth in [5, 4, 3]:
        for output_stride in [8, 16]:
            test_depth(depth, output_stride)
    print("all pass")
```
### Output
```python
Encoder Depth: 5 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 5 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 4 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 4 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 3 | Output Stride: 8 : Input/Output Shape (256, 256)/(256, 256)
Encoder Depth: 3 | Output Stride: 16 : Input/Output Shape (256, 256)/(256, 256)
all pass
```