### PR TITLE
Dependencies: packaging required for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
     'sphinx-book-theme',
 ]
 test = [
+    'packaging',
     'pytest',
     'pytest-cov',
     'pytest-xdist',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
+packaging==24.2
 pytest==8.3.4
 pytest-xdist==3.6.1
 pytest-cov==6.0.0


### PR DESCRIPTION
As of #1011, there is a new dependency on `packaging`