### PR TITLE
Load model with mismatched sizes

### DIFF
--- a/docs/save_load.rst
+++ b/docs/save_load.rst
@@ -40,6 +40,14 @@ For example:
     # Alternatively, load the model directly from the Hugging Face Hub
     model = smp.from_pretrained('username/my-model')
 
+Loading pre-trained model with different number of classes for fine-tuning:
+
+.. code:: python
+
+    import segmentation_models_pytorch as smp
+
+    model = smp.from_pretrained('<path-or-repo-name>', classes=5, strict=False)
+
 Saving model Metrics and Dataset Name
 -------------------------------------
 

--- a/examples/segformer_inference_pretrained.ipynb
+++ b/examples/segformer_inference_pretrained.ipynb
@@ -13,9 +13,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# fix for HF hub download\n",
-    "# see PR https://github.com/albumentations-team/albumentations/pull/2171\n",
-    "!pip install -U git+https://github.com/qubvel/albumentations@patch-2"
+    "# make sure you have the latest version of the libraries\n",
+    "!pip install -U segmentation-models-pytorch\n",
+    "!pip install albumentations matplotlib requests pillow"
    ]
   },
   {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,36 @@
+import torch
+import tempfile
+import segmentation_models_pytorch as smp
+
+import pytest
+
+
+def test_from_pretrained_with_mismatched_keys():
+    orginal_model = smp.Unet(classes=1)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        orginal_model.save_pretrained(temp_dir)
+
+        # we should catch warning here and check if there specific keys there
+        with pytest.warns(UserWarning):
+            restored_model = smp.from_pretrained(temp_dir, classes=2, strict=False)
+
+    assert restored_model.segmentation_head[0].out_channels == 2
+
+    # verify all the weight are the same expect mismatched ones
+    original_state_dict = orginal_model.state_dict()
+    restored_state_dict = restored_model.state_dict()
+
+    expected_mismatched_keys = [
+        "segmentation_head.0.weight",
+        "segmentation_head.0.bias",
+    ]
+    mismatched_keys = []
+    for key in original_state_dict:
+        if key not in expected_mismatched_keys:
+            assert torch.allclose(original_state_dict[key], restored_state_dict[key])
+        else:
+            mismatched_keys.append(key)
+
+    assert len(mismatched_keys) == 2
+    assert sorted(mismatched_keys) == sorted(expected_mismatched_keys)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,10 +6,10 @@ import pytest
 
 
 def test_from_pretrained_with_mismatched_keys():
-    orginal_model = smp.Unet(classes=1)
+    original_model = smp.Unet(classes=1)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        orginal_model.save_pretrained(temp_dir)
+        original_model.save_pretrained(temp_dir)
 
         # we should catch warning here and check if there specific keys there
         with pytest.warns(UserWarning):
@@ -18,7 +18,7 @@ def test_from_pretrained_with_mismatched_keys():
     assert restored_model.segmentation_head[0].out_channels == 2
 
     # verify all the weight are the same expect mismatched ones
-    original_state_dict = orginal_model.state_dict()
+    original_state_dict = original_model.state_dict()
     restored_state_dict = restored_model.state_dict()
 
     expected_mismatched_keys = [


### PR DESCRIPTION
Allows to load pretrained model with different number of channels

For example:

```python
import segmentation_models_pytorch as smp

model = smp.from_pretrained("smp-hub/segformer-b2-1024x1024-city-160k", classes=5, strict=False)
```

Reported in:
 - https://github.com/qubvel-org/segmentation_models.pytorch/issues/1019