### PR TITLE
Fix #1125

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,7 +53,7 @@ You are done! Now you can train your model with your favorite framework, or as s
 
     for images, gt_masks in dataloader:
 
-        predicted_mask = model(image)
+        predicted_mask = model(images)
         loss = loss_fn(predicted_mask, gt_masks)
 
         loss.backward()


### PR DESCRIPTION
 Corrected small typo on line 56 of the Quickstart Guide

Fixes #1125