### PR TITLE
Explicitly set `reduction` for Focal loss

### DIFF
--- a/segmentation_models_pytorch/losses/focal.py
+++ b/segmentation_models_pytorch/losses/focal.py
@@ -45,6 +45,7 @@ class FocalLoss(_Loss):
 
         self.mode = mode
         self.ignore_index = ignore_index
+        self.reduction = reduction
         self.focal_loss_fn = partial(
             focal_loss_with_logits,
             alpha=alpha,


### PR DESCRIPTION
Focal loss have a `reduction` parameter, but it is not set as a `self.reduction` value.

This does not affect loss functionality, but it can be misleading, because by default `__init__` function of `_Loss` sets `self.reduction` to `"mean"`.

For example:
```
>>> loss = smp.losses.FocalLoss(..., reduction="none")
>>> loss.reduction
'mean'
```

This can make checks like this fail, while they should pass
```
if hasattr(loss, "reduction") and loss.reduction != "none":
    raise ValueError("basic loss must have reduction = none")
```

This is a purely cosmetical addition that should not affect anything but can improve user experience