### PR TITLE
Fix DPT for non-power-of-two patch strides

### DIFF
--- a/segmentation_models_pytorch/decoders/dpt/decoder.py
+++ b/segmentation_models_pytorch/decoders/dpt/decoder.py
@@ -85,9 +85,14 @@ class ReassembleBlock(nn.Module):
         in_channels: int,
         mid_channels: int,
         out_channels: int,
-        upsample_factor: int,
+        upsample_factor: float,
     ):
         super().__init__()
+
+        if upsample_factor <= 0:
+            raise ValueError(
+                f"upsample_factor must be greater than zero, got {upsample_factor}"
+            )
 
         self.project_to_out_channel = nn.Conv2d(
             in_channels=in_channels,
@@ -95,7 +100,10 @@ class ReassembleBlock(nn.Module):
             kernel_size=1,
         )
 
-        if upsample_factor > 1.0:
+        # Preserve learned resampling for integer ratios. Truncating fractional
+        # ratios (for example, 14 / 4) produces incompatible pyramid sizes.
+        self.upsample_factor = upsample_factor
+        if upsample_factor > 1.0 and float(upsample_factor).is_integer():
             self.upsample = nn.ConvTranspose2d(
                 in_channels=mid_channels,
                 out_channels=mid_channels,
@@ -104,7 +112,7 @@ class ReassembleBlock(nn.Module):
             )
         elif upsample_factor == 1.0:
             self.upsample = nn.Identity()
-        else:
+        elif float(1 / upsample_factor).is_integer():
             self.upsample = nn.Conv2d(
                 in_channels=mid_channels,
                 out_channels=mid_channels,
@@ -112,6 +120,8 @@ class ReassembleBlock(nn.Module):
                 stride=int(1 / upsample_factor),
                 padding=1,
             )
+        else:
+            self.upsample = None
 
         self.project_to_feature_dim = nn.Conv2d(
             in_channels=mid_channels,
@@ -123,7 +133,15 @@ class ReassembleBlock(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.project_to_out_channel(x)
-        x = self.upsample(x)
+        if self.upsample is None:
+            target_size = tuple(
+                max(1, int(size * self.upsample_factor)) for size in x.shape[-2:]
+            )
+            x = nn.functional.interpolate(
+                x, size=target_size, mode="bilinear", align_corners=True
+            )
+        else:
+            x = self.upsample(x)
         x = self.project_to_feature_dim(x)
         return x
 
@@ -188,6 +206,14 @@ class FusionBlock(nn.Module):
     ) -> torch.Tensor:
         feature = self.residual_conv_block1(feature)
         if previous_feature is not None:
+            # Fractional pyramid ratios can round adjacent levels differently.
+            if previous_feature.shape[-2:] != feature.shape[-2:]:
+                previous_feature = nn.functional.interpolate(
+                    previous_feature,
+                    size=feature.shape[-2:],
+                    mode="bilinear",
+                    align_corners=True,
+                )
             feature = feature + previous_feature
         feature = self.residual_conv_block2(feature)
         feature = nn.functional.interpolate(
@@ -308,13 +334,26 @@ class DPTSegmentationHead(nn.Module):
         self.activation = Activation(activation)
         self.upsampling_factor = upsampling
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        output_size: Optional[tuple[int, int]] = None,
+    ) -> torch.Tensor:
         head_output = self.head(x)
-        resized_output = nn.functional.interpolate(
-            head_output,
-            scale_factor=self.upsampling_factor,
-            mode="bilinear",
-            align_corners=True,
-        )
+        if output_size is None:
+            resized_output = nn.functional.interpolate(
+                head_output,
+                scale_factor=self.upsampling_factor,
+                mode="bilinear",
+                align_corners=True,
+            )
+        else:
+            # A fixed scale factor cannot recover non-power-of-two input sizes.
+            resized_output = nn.functional.interpolate(
+                head_output,
+                size=output_size,
+                mode="bilinear",
+                align_corners=True,
+            )
         activation_output = self.activation(resized_output)
         return activation_output

--- a/segmentation_models_pytorch/decoders/dpt/model.py
+++ b/segmentation_models_pytorch/decoders/dpt/model.py
@@ -159,7 +159,7 @@ class DPT(SegmentationModel):
 
         features, prefix_tokens = self.encoder(x)
         decoder_output = self.decoder(features, prefix_tokens)
-        masks = self.segmentation_head(decoder_output)
+        masks = self.segmentation_head(decoder_output, output_size=x.shape[-2:])
 
         if self.classification_head is not None:
             labels = self.classification_head(features[-1])

--- a/tests/models/test_dpt.py
+++ b/tests/models/test_dpt.py
@@ -2,7 +2,10 @@ import pytest
 import inspect
 import torch
 import segmentation_models_pytorch as smp
-
+from segmentation_models_pytorch.decoders.dpt.decoder import (
+    DPTDecoder,
+    DPTSegmentationHead,
+)
 from tests.models import base
 from tests.utils import (
     slow_test,
@@ -58,3 +61,49 @@ class TestDPTModel(base.BaseModelTester):
         )
         max_diff = torch.max(torch.abs(expected_logits_slice - resulted_logits_slice))
         self.assertTrue(is_close, f"Max diff: {max_diff}")
+
+
+def test_patch14_encoder():
+    model = smp.DPT(
+        encoder_name="tu-eva02_tiny_patch14_224",
+        encoder_weights=None,
+        decoder_intermediate_channels=(16, 16, 16, 16),
+        decoder_fusion_channels=16,
+        classes=2,
+    ).eval()
+
+    with torch.inference_mode():
+        masks = model(torch.randn(1, 3, 224, 224))
+
+    assert model.encoder.output_strides == [14, 14, 14, 14]
+    assert masks.shape == (1, 2, 224, 224)
+
+
+def test_non_power_of_two_patch_stride_with_odd_feature_sizes():
+    input_size = 518
+    patch_size = 14
+    feature_size = input_size // patch_size
+    encoder_output_strides = (patch_size,) * 4
+
+    decoder = DPTDecoder(
+        encoder_out_channels=(8, 8, 8, 8),
+        encoder_output_strides=encoder_output_strides,
+        encoder_has_prefix_tokens=False,
+        readout="ignore",
+        intermediate_channels=(4, 4, 4, 4),
+        fusion_channels=4,
+    ).eval()
+    head = DPTSegmentationHead(in_channels=4, out_channels=2).eval()
+    features = [torch.randn(1, 8, feature_size, feature_size) for _ in range(4)]
+
+    with torch.inference_mode():
+        reassembled_features = [
+            block(feature)
+            for block, feature in zip(decoder.reassemble_blocks, features)
+        ]
+        decoder_output = decoder(features, [None] * 4)
+        masks = head(decoder_output, output_size=(input_size, input_size))
+
+    expected_sizes = [input_size // stride for stride in (4, 8, 16, 32)]
+    assert [feature.shape[-1] for feature in reassembled_features] == expected_sizes
+    assert masks.shape == (1, 2, input_size, input_size)


### PR DESCRIPTION
Fixes #1328.

## Summary

DPT currently converts each encoder stride into a reassembly factor and then truncates that factor to an integer convolution stride. For ViT/14 encoders the required factors are 3.5, 1.75, 0.875, and 0.4375, so the resulting feature maps do not form a compatible pyramid and fusion fails with a tensor-size mismatch.

This change:

- keeps the existing learned transposed-convolution and strided-convolution paths when the resize ratio is exactly representable by an integer stride;
- uses bilinear interpolation for fractional reassembly ratios, producing the intended 1/4, 1/8, 1/16, and 1/32 feature scales;
- aligns adjacent fusion features when rounding odd spatial dimensions yields a one-pixel difference;
- resizes final logits to the original input dimensions instead of assuming that one final 2x resize can always recover them.

The standard patch-8, patch-16, and patch-32 paths retain their existing reassembly modules and state dictionaries.

## Tests

- `python -m pytest -q -n 2 tests/ --non-marked-only` (208 passed, 7 skipped, 213 subtests passed)
- `python -m pytest -q tests/models/test_dpt.py --non-marked-only` (7 passed)
- existing DPT checkpoint output preservation test (1 passed)
- existing DPT compile and strict export tests (2 passed)
- patch-14 model compiled with `torch.compile` and exported with strict `torch.export`; both returned `(1, 2, 224, 224)`
- `ruff check --no-fix .`
- `ruff format --check .` (138 files already formatted)
- `git diff --check`

Regression coverage includes an actual `eva02_tiny_patch14_224` encoder and a synthetic 518-pixel input pyramid, where fractional target sizes also exercise the odd-size fusion path.